### PR TITLE
Add ConCat oauth config.

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -71,6 +71,21 @@ return [
     'setup_admin_password'    => env('SETUP_ADMIN_PASSWORD', null),
 
     'oauth'                   => [
+        'concat' => [
+            'name' => 'ConCat',
+            'client_id' => env('OAUTH_CLIENT_ID', null),
+            'client_secret' => env('OAUTH_CLIENT_SECRET', null),
+            'url_auth' => env('OAUTH_URL_AUTHORIZE', null),
+            'url_token' => env('OAUTH_URL_ACCESS_TOKEN', null),
+            'url_info' => env('OAUTH_URL_RESOURCE', null), // urlResourceOwnerDetails
+            'scope' => ['pii:basic', 'con:read'],
+            'id' => 'id',
+            'username' => 'username',
+            'first_name' => 'firstName',
+            'last_name' => 'lastName',
+            // I don't know why this doesn't work.
+            // 'hidden' => !empty(env('OAUTH_URL_AUTHORIZE', null)),
+        ]
         // '[name]' => [config]
         /*
         '[name]' => [


### PR DESCRIPTION
Fair warning, I'm not super versed in PHP. If there is a better way to do this, please let me know. 

Official concat docs are here: https://concat.app/docs/api/gettingstarted/oauth

We may want different scopes, depending on what information we want from the user.

Example concat config:

```
            'client_id' => 1,
            'client_secret' => '69afba5a31da4092b6354b03072a3f10',
            'url_auth' => 'https://my-cool-concat-website.com/oauth/authorize',
            'url_token' => 'https://my-cool-concat-website.com/api/oauth/token',
            'url_info' =>  'https://my-cool-concat-website.com/api/users/current',
```