### PR TITLE
Remove dead delete button.

### DIFF
--- a/resources/views/pages/locations/index.twig
+++ b/resources/views/pages/locations/index.twig
@@ -68,17 +68,6 @@
                                                 ) }}
 
                                                 {{ m.edit(url('/admin/locations/edit/' ~ location.id), {'class': 'm-1'}) }}
-
-                                                <form method="post" class="ps-1">
-                                                    {{ csrf() }}
-                                                    {{ f.hidden('id', location.id) }}
-                                                    {{ f.delete(null, {
-                                                        'size': 'sm',
-                                                        'confirm_title': __('location.delete.title', [location.name|e]),
-                                                        'confirm_button_text': __('form.delete'),
-                                                        'class': 'm-1',
-                                                    }) }}
-                                                </form>
                                             {% else %}
                                                 {{ m.button(
                                                     __('form.view'),


### PR DESCRIPTION
You cannot delete locations from the main locations page. So I removed the delete button. Before:

![image](https://github.com/user-attachments/assets/52a37ad4-b8cc-41b1-8ae7-39f77b177309)

And after:

![image](https://github.com/user-attachments/assets/18a1a9c8-04cc-467f-b9a2-fccf52809fee)

Don't worry, you can still delete locations. But you click on the pencil edit icon first. Then scroll down. (Woops!)

![image](https://github.com/user-attachments/assets/5358d171-2c2f-4482-a365-42fc4d198be0)
